### PR TITLE
Add Exception for empty columns and columns that doesn't exists in schema

### DIFF
--- a/src/Exceptions/EmptyColumnsException.php
+++ b/src/Exceptions/EmptyColumnsException.php
@@ -1,0 +1,9 @@
+<?php 
+
+namespace Unlu\Laravel\Api\Exceptions;
+
+use Exception;
+
+class EmptyColumnsException extends Exception
+{
+}

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Unlu\Laravel\Api\Exceptions\UnknownColumnException;
+use Unlu\Laravel\Api\Exceptions\EmptyColumnsException;
 use Unlu\Laravel\Api\UriParser;
 
 class QueryBuilder
@@ -148,17 +149,23 @@ class QueryBuilder
         $this->columns = $this->relationColumns = [];
 
         array_map([$this, 'setColumn'], $columns);
+
+        if( $this->hasColumns($columns) == 0) {
+            throw new EmptyColumnsException("Columns are empty");
+        }
     }
 
     private function setColumn($column)
     {
+    
         if ($this->isRelationColumn($column)) {
             return $this->appendRelationColumn($column);
         }
-        
+
         if (! $this->hasTableColumn($column)) {
             throw new UnknownColumnException("Unknown column '{$column}'");
         }
+
 
         $this->columns[] = $column;
     }
@@ -252,6 +259,7 @@ class QueryBuilder
             throw new UnknownColumnException("Unknown column '{$key}'");
         }
 
+
         $this->query->where($key, $operator, $value);
     }
 
@@ -306,6 +314,11 @@ class QueryBuilder
     private function hasOffset()
     {
         return ($this->offset != 0);
+    }
+
+    private function hasColumns($columns)
+    {
+        return (count($columns));
     }
 
     private function hasRelationColumns()

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -155,6 +155,10 @@ class QueryBuilder
         if ($this->isRelationColumn($column)) {
             return $this->appendRelationColumn($column);
         }
+        
+        if (! $this->hasTableColumn($column)) {
+            throw new UnknownColumnException("Unknown column '{$column}'");
+        }
 
         $this->columns[] = $column;
     }


### PR DESCRIPTION
I added an exception when you put nothing in (columns=) to avoid an SQLState , and added a throw exception when columns in (columns=id,foo) doesn't exists in the schema
