### PR TITLE
Fix pagination on models with scopes

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -413,7 +413,11 @@ class QueryBuilder
 
         $perPage = $perPage ?: $this->model->getPerPage();
 
-        $query = $this->query->getQuery();
+        if (method_exists($this->query, 'toBase')) {
+            $query = $this->query->toBase();
+        } else {
+            $query = $this->query->getQuery();
+        }
 
         $total = $query->getCountForPagination();
 


### PR DESCRIPTION
If a model has some scopes, like a most common one - `SoftDeletes`. If there are some records in the corresponding table in database, and one of them is soft deleted, the `total` on pagination would still include that deleted one.

Refer to [this line](https://github.com/laravel/framework/blob/v5.4.27/src/Illuminate/Database/Eloquent/Builder.php#L689), I'll suggest using `toBase` instead of `getQuery` which would apply the scopes to the model.