### PR TITLE
Do not exceed maximum limit

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -104,6 +104,10 @@ class QueryBuilder
         if (!$this->hasLimit()) {
             throw new Exception("You can't use unlimited option for pagination", 1);
         }
+        
+        if ($this->limit > config('api-query-builder.limit')) {
+ +			$this->limit = config('api-query-builder.limit');
+ +		}
 
         $result = $this->basePaginate($this->limit);
 


### PR DESCRIPTION
When pagination is set.
The limit variable (from GET) can't be greater than application definitions.