### PR TITLE
Hotfix Issue #52

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -409,7 +409,9 @@ class QueryBuilder
      */
     private function basePaginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
     {
-        $page = $page ?: BasePaginator::resolveCurrentPage($pageName);
+        if (is_null($page)) {
+            $page = $this->page ?: BasePaginator::resolveCurrentPage($pageName);
+        }
 
         $perPage = $perPage ?: $this->model->getPerPage();
 

--- a/src/UriParser.php
+++ b/src/UriParser.php
@@ -80,7 +80,7 @@ class UriParser
     {
         $explode = explode('?', $uri);
 
-        $this->queryUri = (isset($explode[1])) ? rawurldecode($explode[1]) : null;
+        $this->queryUri = (isset($explode[1])) ? rawurldecode($explode[1]) : '';
     }
 
     private function setQueryParameters($queryUri)


### PR DESCRIPTION
- Changed return value from null to empty string in `UriParser::setQueryUri` method, if query params were not pass. It needs, so that `Paginator::setQueryUri` str_replace get empty string instead of `null` and does not crash.
- Added additional step for identification current page before processing pagination query in the `QueryBuilder::basePaginate` method. It needs, because the `QueryBuilder::basePaginate`  is private and is called only once and only in this class. The method calls without `$page` parameter passing, so that the `$page` will always be `1` and the `Paginator::items` will have incorrect items.